### PR TITLE
ci: add workflows for automation fork

### DIFF
--- a/.github/workflows/build-automation.yml
+++ b/.github/workflows/build-automation.yml
@@ -1,0 +1,37 @@
+# Build Godot automation branch using upstream workflows
+
+name: Build Godot Automation
+
+on:
+  push:
+    branches: [automation]
+  pull_request:
+    branches: [automation]
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 4 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: Static Checks
+    uses: ./.github/workflows/static_checks.yml
+
+  linux-build:
+    name: Linux
+    needs: static-checks
+    uses: ./.github/workflows/linux_builds.yml
+
+  windows-build:
+    name: Windows
+    needs: static-checks
+    uses: ./.github/workflows/windows_builds.yml
+
+  macos-build:
+    name: macOS
+    needs: static-checks
+    uses: ./.github/workflows/macos_builds.yml

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,96 @@
+# Nightly job to sync with upstream godotengine/godot
+
+name: Sync Upstream
+
+on:
+  schedule:
+    # Run at 3 AM UTC every night
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+      - name: Add upstream and fetch
+        run: |
+          git remote add upstream https://github.com/godotengine/godot.git
+          git fetch upstream master
+          git fetch origin automation
+
+      - name: Update master from upstream
+        run: |
+          git checkout master
+          git reset --hard upstream/master
+          git push origin master --force
+
+      - name: Rebase automation onto master
+        id: rebase
+        continue-on-error: true
+        run: |
+          git checkout automation
+          if git rebase master; then
+            echo "rebase_success=true" >> $GITHUB_OUTPUT
+          else
+            git rebase --abort
+            echo "rebase_success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push automation branch
+        if: steps.rebase.outputs.rebase_success == 'true'
+        run: |
+          git push origin automation --force-with-lease
+
+      - name: Create issue if rebase failed
+        if: steps.rebase.outputs.rebase_success == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Upstream sync failed - manual rebase required';
+            const body = `The nightly rebase of \`automation\` onto \`master\` failed due to conflicts.
+
+            **Action required:**
+
+            \`\`\`bash
+            git fetch origin
+            git checkout automation
+            git rebase origin/master
+            # Resolve conflicts
+            git push origin automation --force-with-lease
+            \`\`\`
+
+            Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'upstream-sync'
+            });
+
+            if (issues.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['upstream-sync', 'needs-attention']
+              });
+            }
+
+  trigger-build:
+    needs: sync
+    if: success()
+    uses: ./.github/workflows/build-automation.yml


### PR DESCRIPTION
## Summary

Add CI workflows to maintain the automation fork.

### Workflows

- **sync-upstream.yml**: Nightly sync of `master` from `godotengine/godot`, then rebase `automation` onto updated master
- **build-automation.yml**: Build editor and templates for Linux, Windows, and macOS with artifact upload

### Branch Strategy

- `master` - clean mirror of upstream
- `automation` - our commits rebased on top of master