### PR TITLE
Add PlayGodot integration test workflow

### DIFF
--- a/.github/workflows/playgodot-integration.yml
+++ b/.github/workflows/playgodot-integration.yml
@@ -5,7 +5,7 @@ name: PlayGodot Integration Tests
 
 on:
   workflow_run:
-    workflows: ["Build Godot Automation"]
+    workflows: ["🔗 GHA"]
     types: [completed]
     branches: [automation]
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
       - name: Download Godot artifact
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build-automation.yml
+          workflow: runner.yml
           workflow_conclusion: success
           name: linux-editor-mono
           path: godot-bin
@@ -33,7 +33,7 @@ jobs:
         if: failure() || hashFiles('godot-bin/godot.*') == ''
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build-automation.yml
+          workflow: runner.yml
           workflow_conclusion: success
           name: linux-editor-mono
           path: godot-bin


### PR DESCRIPTION
Adds automated integration testing that runs against the Godot automation build. This workflow:
- Triggers on successful automation builds or manual dispatch
- Downloads the linux-editor-mono artifact
- Runs PlayGodot unit tests and tic-tac-toe integration tests
- Uses xvfb for headless Godot execution

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
